### PR TITLE
Polishing itinerary home

### DIFF
--- a/frontend/src/components/clear-local-journals.tsx
+++ b/frontend/src/components/clear-local-journals.tsx
@@ -1,0 +1,11 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export async function clearLocalJournals() {
+  try {
+    await AsyncStorage.removeItem('journals');
+    await AsyncStorage.removeItem('journalEntries');
+    console.log('Local journals cleared.');
+  } catch (error) {
+    console.error('Error clearing local journals:', error);
+  }
+}

--- a/frontend/src/components/google-map.tsx
+++ b/frontend/src/components/google-map.tsx
@@ -34,8 +34,8 @@ const GoogleMapComponent: React.FC<GoogleMapComponentProps> = ({
   const hardCodedDefaultRegion: Region = {
     latitude: -3.745,
     longitude: -38.523,
-    latitudeDelta: 5.0,      // Zoomed out default
-    longitudeDelta: 5.0,     // Zoomed out default
+    latitudeDelta: 5.0,    
+    longitudeDelta: 5.0,    
   };
 
   const finalRegion = region ?? defaultRegion ?? hardCodedDefaultRegion;

--- a/frontend/src/components/itinerary-creation.tsx
+++ b/frontend/src/components/itinerary-creation.tsx
@@ -45,8 +45,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#fff',
     padding: 20,
-    paddingTop: 50, // adjust this if needed
-    // Removed justifyContent: 'center' to align content at the top
+    paddingTop: 50, 
   },
   backButtonMinimal: {
     position: 'absolute',
@@ -60,12 +59,12 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     color: '#333',
     alignSelf: 'center',
-    marginTop: 20, // Adjusted to position the title below the back button
+    marginTop: 20, 
     marginBottom: 10,
   },
   plannerContent: {
     marginBottom: 40,
-    marginTop: 20, // add margin to separate from header
+    marginTop: 20, 
   },
   plannerLabel: {
     fontSize: 24,

--- a/frontend/src/components/itinerary-creation.tsx
+++ b/frontend/src/components/itinerary-creation.tsx
@@ -19,6 +19,7 @@ export function ItineraryCreation({ destination, setDestination, onStartTrip, on
       >
         <Ionicons name="arrow-back" size={24} color="#000" />
       </TouchableOpacity>
+      <Text style={styles.headerTitle}>Let's Plan!</Text>
       <View style={styles.plannerContent}>
         <Text style={styles.plannerLabel}>Where to?</Text>
         <TextInput 
@@ -43,19 +44,28 @@ const styles = StyleSheet.create({
   plannerContainer: {
     flex: 1,
     backgroundColor: '#fff',
-    justifyContent: 'center',
     padding: 20,
-    paddingTop: 50,
+    paddingTop: 50, // adjust this if needed
+    // Removed justifyContent: 'center' to align content at the top
   },
   backButtonMinimal: {
     position: 'absolute',
-    top: 10,   // adjust from 47 to 10
+    top: 10,
     left: 10,
     zIndex: 10,
     padding: 5,
   },
+  headerTitle: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    color: '#333',
+    alignSelf: 'center',
+    marginTop: 20, // Adjusted to position the title below the back button
+    marginBottom: 10,
+  },
   plannerContent: {
     marginBottom: 40,
+    marginTop: 20, // add margin to separate from header
   },
   plannerLabel: {
     fontSize: 24,
@@ -82,3 +92,5 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 });
+
+export default ItineraryCreation;

--- a/frontend/src/components/itinerary-locations.tsx
+++ b/frontend/src/components/itinerary-locations.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { View, Text, Image, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 
 export interface Location {
   id?: string;
@@ -11,21 +12,76 @@ interface ItineraryLocationsProps {
   locations: Location[];
 }
 
+interface LocationItemProps {
+  location: Location;
+  index: number;
+  isLast: boolean;
+}
+
+const LocationItem: React.FC<LocationItemProps> = ({ location, index, isLast }) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <View style={styles.locationItemContainer}>
+      {/* Marker Column */}
+      <View style={styles.markerContainer}>
+        <View style={styles.circle}>
+          <Text style={styles.indexText}>{index + 1}</Text>
+        </View>
+        {!isLast && <View style={styles.verticalLine} />}
+      </View>
+      {/* Content Column: Two sub-columns – text (title + triple dots + menu) and image */}
+      <View style={styles.locationContent}>
+        <View style={styles.textContainer}>
+          <Text style={styles.locationTitle}>
+            {location.title || 'Untitled location'}
+          </Text>
+          <TouchableOpacity
+            style={styles.menuButton}
+            onPress={() => setMenuOpen(!menuOpen)}
+          >
+            <Ionicons name="ellipsis-horizontal" size={16} color="#333" />
+          </TouchableOpacity>
+          {menuOpen && (
+            <View style={styles.menuOptions}>
+              <TouchableOpacity
+                style={styles.menuOption}
+                onPress={() => console.log('Edit pressed')}
+              >
+                <Text style={styles.menuOptionText}>Edit</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.menuOption}
+                onPress={() => console.log('Delete pressed')}
+              >
+                <Text style={[styles.menuOptionText, { color: 'red' }]}>Delete</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+        </View>
+        <View style={styles.imageContainer}>
+          {location.photoURI ? (
+            <Image source={{ uri: location.photoURI }} style={styles.locationImage} />
+          ) : (
+            <Text style={styles.noImageText}>No image</Text>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+};
+
 export const ItineraryLocations: React.FC<ItineraryLocationsProps> = ({ locations }) => {
   return (
     <View style={styles.locationsContainer}>
       {locations.length > 0 ? (
         locations.map((loc, index) => (
-          <View key={loc.id || index} style={styles.locationItemContainer}>
-            <Text style={styles.locationTitle}>
-              {loc.title || 'Untitled location'}
-            </Text>
-            {loc.photoURI ? (
-              <Image source={{ uri: loc.photoURI }} style={styles.locationImage} />
-            ) : (
-              <Text style={styles.noImageText}>No image</Text>
-            )}
-          </View>
+          <LocationItem
+            key={loc.id || index}
+            location={loc}
+            index={index}
+            isLast={index === locations.length - 1}
+          />
         ))
       ) : (
         <Text style={styles.noLocationsText}>
@@ -42,29 +98,80 @@ const styles = StyleSheet.create({
   },
   locationItemContainer: {
     flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+    alignItems: 'flex-start', // Align content to the top
+    marginBottom: 10,
     borderWidth: 1,
     borderColor: '#ccc',
     borderRadius: 10,
     padding: 10,
-    marginBottom: 10,
+  },
+  markerContainer: {
+    width: 40,
+    alignItems: 'center',
+    marginRight: 10,
+  },
+  circle: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: 'blue',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  indexText: {
+    color: 'white',
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+  verticalLine: {
+    width: 2,
+    backgroundColor: 'blue',
+    flex: 1,
+    marginTop: 2,
+  },
+  locationContent: {
+    flex: 1,
+    flexDirection: 'row', // Two columns: left for text/menu, right for image
+    justifyContent: 'space-between',
+  },
+  textContainer: {
+    flex: 1,
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
   },
   locationTitle: {
-    flex: 1,
     fontSize: 16,
     color: '#333',
+    marginBottom: 4, // Spacing between title and triple dots
+  },
+  menuButton: {
+    marginTop: 2,
+  },
+  menuOptions: {
+    marginTop: 4,
+    backgroundColor: '#fff',
+    padding: 4,
+    // Removed border styles so no outline is shown for the menu
+  },
+  menuOption: {
+    paddingVertical: 2,
+  },
+  menuOptionText: {
+    fontSize: 14,
+    color: '#333',
+  },
+  imageContainer: {
+    marginLeft: 10,
+    justifyContent: 'center',
   },
   locationImage: {
     width: 80,
     height: 80,
     borderRadius: 10,
-    marginLeft: 10,
   },
   noImageText: {
     fontSize: 12,
     color: 'gray',
-    marginLeft: 10,
   },
   noLocationsText: {
     fontSize: 16,
@@ -73,3 +180,5 @@ const styles = StyleSheet.create({
     marginTop: 20,
   },
 });
+
+export default ItineraryLocations;

--- a/frontend/src/components/place-details-popup.tsx
+++ b/frontend/src/components/place-details-popup.tsx
@@ -1,6 +1,15 @@
-// place-details-popup.tsx
-import React from 'react';
-import { View, Text, ScrollView, StyleSheet, Image, TouchableOpacity, Dimensions } from 'react-native';
+import React, { useState } from 'react';
+import { 
+  View, 
+  Text, 
+  ScrollView, 
+  StyleSheet, 
+  Image, 
+  TouchableOpacity, 
+  Modal, 
+  Pressable, 
+  Dimensions 
+} from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
 interface PlaceDetailsPopupProps {
@@ -14,6 +23,8 @@ export const PlaceDetailsPopup: React.FC<PlaceDetailsPopupProps> = ({
   onClose,
   onAddLocation,
 }) => {
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+
   // Construct image URLs from each photo's photo_reference.
   const imageUrls: string[] =
     details.photos?.map((photo: any) => {
@@ -25,56 +36,75 @@ export const PlaceDetailsPopup: React.FC<PlaceDetailsPopupProps> = ({
 
   const handleAddPress = () => {
     if (onAddLocation) {
-      // Pass the formatted address (if available)
       onAddLocation(details.name || 'Untitled', firstImageUrl, details.formatted_address || '');
     }
   };
 
   return (
-    <View style={styles.overlay}>
-      <View style={styles.popup}>
-        {/* Header Row */}
-        <View style={styles.headerRow}>
-          <TouchableOpacity style={styles.plusButton} onPress={handleAddPress}>
-            <Ionicons name="add" size={24} color="#fff" />
-          </TouchableOpacity>
-          <Text style={styles.placeName}>
-            {details.name || 'Unknown Place'}
-          </Text>
-          <TouchableOpacity style={styles.closeButton} onPress={onClose}>
-            <Ionicons name="close" size={24} color="#000" />
-          </TouchableOpacity>
+    <>
+      <View style={styles.popupContainer}>
+        <View style={styles.popup}>
+          {/* Header Row */}
+          <View style={styles.headerRow}>
+            <TouchableOpacity style={styles.plusButton} onPress={handleAddPress}>
+              <Ionicons name="add" size={24} color="#fff" />
+            </TouchableOpacity>
+            <Text style={styles.placeName}>
+              {details.name || 'Unknown Place'}
+            </Text>
+            <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+              <Ionicons name="close" size={24} color="#000" />
+            </TouchableOpacity>
+          </View>
+          {/* Vertical Images Scroll */}
+          <ScrollView
+            style={styles.imagesContainer}
+            contentContainerStyle={styles.imagesContentContainer}
+          >
+            {imageUrls.length > 0 ? (
+              imageUrls.map((url, index) => (
+                <TouchableOpacity key={index} onPress={() => setSelectedImage(url)}>
+                  <Image source={{ uri: url }} style={styles.image} />
+                </TouchableOpacity>
+              ))
+            ) : (
+              <Text style={styles.noImagesText}>No images available.</Text>
+            )}
+          </ScrollView>
         </View>
-        {/* Vertical Images Scroll */}
-        <ScrollView
-          style={styles.imagesContainer}
-          contentContainerStyle={styles.imagesContentContainer}
-        >
-          {imageUrls.length > 0 ? (
-            imageUrls.map((url, index) => (
-              <Image key={index} source={{ uri: url }} style={styles.image} />
-            ))
-          ) : (
-            <Text style={styles.noImagesText}>No images available.</Text>
-          )}
-        </ScrollView>
       </View>
-    </View>
+      {/* Expanded Image Modal */}
+      <Modal
+        visible={!!selectedImage}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setSelectedImage(null)}
+      >
+        <Pressable style={styles.fullScreenOverlay} onPress={() => setSelectedImage(null)}>
+          <View style={styles.imageContainer}>
+            <Image
+              source={{ uri: selectedImage! }}
+              style={styles.expandedImage}
+              resizeMode="contain"
+            />
+          </View>
+        </Pressable>
+      </Modal>
+    </>
   );
 };
 
 const screenHeight = Dimensions.get('window').height;
 
 const styles = StyleSheet.create({
-  overlay: {
+  popupContainer: {
     position: 'absolute',
     bottom: 0,
     left: 0,
     right: 0,
-    backgroundColor: 'rgba(0,0,0,0.3)',
   },
   popup: {
-    height: screenHeight * 0.5,  // Takes up half the screen
+    height: screenHeight * 0.5,  // Popup takes up half the screen
     backgroundColor: '#fff',
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
@@ -124,4 +154,22 @@ const styles = StyleSheet.create({
     color: 'gray',
     textAlign: 'center',
   },
+  fullScreenOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.7)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  imageContainer: {
+    width: '90%',
+    height: '90%',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  expandedImage: {
+    width: '100%',
+    height: '100%',
+  },
 });
+
+export default PlaceDetailsPopup;

--- a/frontend/src/components/profile-posts.tsx
+++ b/frontend/src/components/profile-posts.tsx
@@ -4,7 +4,6 @@ import { View, Text, StyleSheet, TouchableOpacity, Image } from 'react-native';
 export interface Post {
   uuid: string,
   journal: string,
-  journal: string,
   title: string,
   date: string,
   location: { lat: any; lng: any; place_id: any } | null,
@@ -17,7 +16,6 @@ export interface Post {
 
 interface ProfilePostsProps {
   journalEntries: Post[];
-  selectedJournal: string | null;
   selectedJournal: string | null;
   onDelete: (id: string) => void;
   onEdit: (post: Post) => void;

--- a/frontend/src/components/small-post.tsx
+++ b/frontend/src/components/small-post.tsx
@@ -1,37 +1,52 @@
 import React from 'react';
-import { TouchableOpacity, ImageBackground, Text, StyleSheet } from 'react-native';
+import {
+  TouchableOpacity,
+  Text,
+  ImageBackground,
+  StyleSheet,
+  ImageSourcePropType,
+} from 'react-native';
 
-export default function SmallPost({ text, onPress, imageSource }) {
+interface SmallPostProps {
+  text: string;
+  onPress: () => void;
+  imageSource: ImageSourcePropType;
+}
+
+export default function SmallPost({ text, onPress, imageSource }: SmallPostProps) {
   return (
-    <TouchableOpacity style={styles.smallPost} onPress={onPress}>
-      <ImageBackground 
+    <TouchableOpacity style={styles.container} onPress={onPress}>
+      <ImageBackground
         source={imageSource}
-        style={styles.background}
-        imageStyle={{ borderRadius: 10 }}
+        style={styles.imageBackground}
+        resizeMode="cover"
       >
-        <Text style={styles.smallPostText}>{text}</Text>
+        <Text style={styles.text}>{text}</Text>
       </ImageBackground>
     </TouchableOpacity>
   );
 }
 
 const styles = StyleSheet.create({
-  smallPost: {
-    width: 100,
-    height: 100,
+  container: {
+    width: 120,
+    height: 120,
     marginRight: 10,
-  },
-  background: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
     borderRadius: 10,
     overflow: 'hidden',
+    backgroundColor: '#ccc', // fallback background color
   },
-  smallPostText: {
-    fontSize: 14,
-    fontWeight: 'bold',
+  imageBackground: {
+    flex: 1,
+    justifyContent: 'flex-end', // positions text at the bottom
+    padding: 5,
+  },
+  text: {
     color: '#fff',
-    textAlign: 'center',
+    fontWeight: 'bold',
+    fontSize: 16,
+    textShadowColor: 'rgba(0, 0, 0, 0.6)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
   },
 });

--- a/frontend/src/components/small-post.tsx
+++ b/frontend/src/components/small-post.tsx
@@ -1,19 +1,34 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   TouchableOpacity,
   Text,
   ImageBackground,
   StyleSheet,
+  View,
   ImageSourcePropType,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { deleteItineraryAndAllLocations } from '../services/itinerary-service';
 
 interface SmallPostProps {
   text: string;
   onPress: () => void;
   imageSource: ImageSourcePropType;
+  itineraryId: string;
+  fetchItineraries: () => Promise<void>;
+  onDelete?: () => void; // optional delete callback, if needed
 }
 
-export default function SmallPost({ text, onPress, imageSource }: SmallPostProps) {
+export default function SmallPost({
+  text,
+  onPress,
+  imageSource,
+  itineraryId,
+  fetchItineraries,
+  onDelete,
+}: SmallPostProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
     <TouchableOpacity style={styles.container} onPress={onPress}>
       <ImageBackground
@@ -21,6 +36,29 @@ export default function SmallPost({ text, onPress, imageSource }: SmallPostProps
         style={styles.imageBackground}
         resizeMode="cover"
       >
+        {/* Menu button in top left */}
+        <View style={styles.menuContainer}>
+          <TouchableOpacity onPress={() => setMenuOpen(!menuOpen)}>
+            <Ionicons name="ellipsis-horizontal" size={18} color="#fff" />
+          </TouchableOpacity>
+          {menuOpen && (
+            <View style={styles.dropdown}>
+              <TouchableOpacity
+                onPress={async () => {
+                  try {
+                    await deleteItineraryAndAllLocations(itineraryId);
+                    await fetchItineraries();
+                    if (onDelete) onDelete();
+                  } catch (err) {
+                    console.error('Failed to delete itinerary:', err);
+                  }
+                }}
+              >
+                <Text style={styles.dropdownText}>Delete</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+        </View>
         <Text style={styles.text}>{text}</Text>
       </ImageBackground>
     </TouchableOpacity>
@@ -34,11 +72,11 @@ const styles = StyleSheet.create({
     marginRight: 10,
     borderRadius: 10,
     overflow: 'hidden',
-    backgroundColor: '#ccc', // fallback background color
+    backgroundColor: '#ccc',
   },
   imageBackground: {
     flex: 1,
-    justifyContent: 'flex-end', // positions text at the bottom
+    justifyContent: 'flex-end',
     padding: 5,
   },
   text: {
@@ -48,5 +86,22 @@ const styles = StyleSheet.create({
     textShadowColor: 'rgba(0, 0, 0, 0.6)',
     textShadowOffset: { width: 0, height: 1 },
     textShadowRadius: 2,
+  },
+  menuContainer: {
+    position: 'absolute',
+    top: 5,
+    left: 5,
+    zIndex: 2,
+  },
+  dropdown: {
+    marginTop: 5,
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    borderRadius: 4,
+    paddingHorizontal: 5,
+    paddingVertical: 2,
+  },
+  dropdownText: {
+    color: 'red',
+    fontSize: 12,
   },
 });

--- a/frontend/src/screens/home-screen.tsx
+++ b/frontend/src/screens/home-screen.tsx
@@ -75,6 +75,8 @@ export default function HomeScreen({ navigation }) {
                 key={itinerary.uuid}
                 text={itinerary.title}
                 onPress={() => handleItineraryPress(itinerary)}
+                itineraryId={itinerary.uuid}
+                fetchItineraries={fetchItineraries}
                 imageSource={
                   itineraryImages[itinerary.uuid]
                     ? { uri: itineraryImages[itinerary.uuid] }

--- a/frontend/src/screens/home-screen.tsx
+++ b/frontend/src/screens/home-screen.tsx
@@ -1,42 +1,73 @@
-import React, { useState, useEffect } from 'react';
-import { ScrollView, View, Text, TouchableOpacity, StyleSheet, ImageBackground } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import React, { useState, useEffect, useCallback } from 'react';
+import { ScrollView, View, StyleSheet } from 'react-native';
 import LargePost from '../components/large-post';
 import SmallPost from '../components/small-post';
 import { getItineraries } from '../services/itinerary-service';
+import { getFirstImageForItineraryTitle } from '../services/maps-service';
+import { useFocusEffect } from '@react-navigation/native';
 
 export default function HomeScreen({ navigation }) {
   const [itineraries, setItineraries] = useState([]);
+  const [itineraryImages, setItineraryImages] = useState({});
 
-  // Fetch itineraries on mount
-  useEffect(() => {
-    async function fetchItineraries() {
-      try {
-        const data = await getItineraries();
-        setItineraries(data);
-      } catch (error) {
-        console.error('Error fetching itineraries:', error);
-      }
+  // Function to fetch itineraries
+  const fetchItineraries = async () => {
+    try {
+      const data = await getItineraries();
+      setItineraries(data);
+    } catch (error) {
+      console.error('Error fetching itineraries:', error);
     }
-    fetchItineraries();
-  }, []);
+  };
+
+  // Re-fetch itineraries when screen gains focus
+  useFocusEffect(
+    useCallback(() => {
+      fetchItineraries();
+    }, [])
+  );
+
+  // After itineraries are fetched, fetch an image for each itinerary title
+  useEffect(() => {
+    async function fetchImages() {
+      const imagesMap = {};
+      await Promise.all(
+        itineraries.map(async (itinerary) => {
+          try {
+            const imageUrl = await getFirstImageForItineraryTitle(itinerary.title);
+            console.log(`Image for ${itinerary.title}:`, imageUrl); // Debug log
+            imagesMap[itinerary.uuid] = imageUrl;
+          } catch (error) {
+            console.error(`Error fetching image for ${itinerary.title}:`, error);
+            // Set a null value so the fallback image is used
+            imagesMap[itinerary.uuid] = null;
+          }
+        })
+      );
+      setItineraryImages(imagesMap);
+      console.log("Itinerary images map:", imagesMap); // Debug log
+    }
+    if (itineraries.length > 0) {
+      fetchImages();
+    }
+  }, [itineraries]);
+  
 
   const handleItineraryPress = (itinerary) => {
-  navigation.navigate('Itinerary', {
-    screen: 'ItineraryDetails',
-    params: { itinerary },
-  });
-};
+    navigation.navigate('Itinerary', {
+      screen: 'ItineraryDetails',
+      params: { itinerary },
+    });
+  };
 
   return (
-    <View
-    >
+    <View>
       <ScrollView contentContainerStyle={styles.container}>
         {/* Small posts */}
         <View style={styles.smallPostsSection}>
-          <ScrollView 
-            horizontal 
-            showsHorizontalScrollIndicator={false} 
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
             contentContainerStyle={styles.smallPostsContainer}
           >
             {itineraries.map((itinerary) => (
@@ -44,7 +75,11 @@ export default function HomeScreen({ navigation }) {
                 key={itinerary.uuid}
                 text={itinerary.title}
                 onPress={() => handleItineraryPress(itinerary)}
-                // Optionally, if your SmallPost supports imageSource, you could pass an image too
+                imageSource={
+                  itineraryImages[itinerary.uuid]
+                    ? { uri: itineraryImages[itinerary.uuid] }
+                    : require('../../assets/arundel-england1.jpg')
+                }
               />
             ))}
           </ScrollView>
@@ -71,11 +106,6 @@ export default function HomeScreen({ navigation }) {
 }
 
 const styles = StyleSheet.create({
-  backgroundImage: {
-    flex: 1,
-    width: '100%',
-    height: '100%',
-  },
   container: {
     paddingBottom: 30,
     backgroundColor: 'transparent',

--- a/frontend/src/screens/home-screen.tsx
+++ b/frontend/src/screens/home-screen.tsx
@@ -99,7 +99,19 @@ export default function HomeScreen({ navigation }) {
           />
           <LargePost 
             imageSource={require('../../assets/tokyo1.jpg')}
-            title="Tokyo" 
+            title="Tokyo, Japan" 
+          />
+          <LargePost 
+            imageSource={require('../../assets/spbg-russia1.jpg')}
+            title="St. Petersburg, Russia" 
+          />
+          <LargePost 
+            imageSource={require('../../assets/norway1.jpg')}
+            title="Norway" 
+          />
+          <LargePost 
+            imageSource={require('../../assets/italy1.jpg')}
+            title="Italy" 
           />
         </View>
       </ScrollView>

--- a/frontend/src/screens/itinerary-details-screen.tsx
+++ b/frontend/src/screens/itinerary-details-screen.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import {
   StyleSheet, View, Text, ScrollView, TouchableOpacity,
-  KeyboardAvoidingView, Platform
+  KeyboardAvoidingView, Platform, ImageBackground
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -12,7 +12,7 @@ import { ItineraryStackParamList } from './itinerary-stack';
 import { ItineraryLocations } from '../components/itinerary-locations';
 
 import { useItineraryMarkers } from '../components/itinerary-map-markers';
-import { getLatLngFromAddress } from '../services/maps-service';
+import { getLatLngFromAddress, getFirstImageForItineraryTitle } from '../services/maps-service';
 
 type ItineraryDetailsScreenProps = StackScreenProps<ItineraryStackParamList, 'ItineraryDetails'>;
 
@@ -24,6 +24,7 @@ export default function ItineraryDetailsScreen({ navigation, route }: ItineraryD
   const [selectedOption, setSelectedOption] = useState<'Itinerary' | 'Map'>('Itinerary');
 
   const { fetchedItinerary, markers, refreshItinerary } = useItineraryMarkers(itinerary.uuid);
+  const [headerImage, setHeaderImage] = useState<string | null>(null);
 
   // If we haven't fetched anything yet, fallback to the initial object
   const displayedItinerary = fetchedItinerary || itinerary;
@@ -46,23 +47,43 @@ export default function ItineraryDetailsScreen({ navigation, route }: ItineraryD
     fetchDefaultRegion();
   }, [destination]);
 
+  useEffect(() => {
+    (async () => {
+      try {
+        const imageUrl = await getFirstImageForItineraryTitle(destination);
+        setHeaderImage(imageUrl);
+      } catch (error) {
+        console.error('Failed to get header image:', error);
+      }
+    })();
+  }, [destination]);
+
   return (
     <KeyboardAvoidingView
       style={styles.keyboardAvoidingContainer}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
     >
-      <SafeAreaView edges={['top', 'left', 'right']} style={styles.container}>
-
-        {/* Header with back button */}
+      {/* The SafeAreaView is used to account for notches, but you can control its padding */}
+      <SafeAreaView edges={['left', 'right']} style={styles.container}>
+      
+        {/* Header with home button and title at bottom left */}
         <View style={styles.header}>
+          {headerImage && (
+            <ImageBackground
+              source={{ uri: headerImage }}
+              style={StyleSheet.absoluteFill}
+              resizeMode="cover"
+            />
+          )}
           <TouchableOpacity
-            style={styles.backButton}
+            style={styles.homeButton}
             onPress={() => navigation.navigate('Home')}
           >
-            <Ionicons name="arrow-back" size={24} color="#000" />
+            <Ionicons name="home" size={24} color="#fff" />
           </TouchableOpacity>
           <Text style={styles.headerText}>Your Trip to {destination}</Text>
         </View>
+
 
         {/* Horizontal tabs: Itinerary / Map */}
         <View style={styles.optionsContainer}>
@@ -113,9 +134,7 @@ export default function ItineraryDetailsScreen({ navigation, route }: ItineraryD
                 itineraryId={itinerary.uuid}
                 itineraryMarkers={markers}
                 onLocationAdded={async () => {
-                  // 1) Re-fetch itinerary and rebuild markers
                   await refreshItinerary();
-                  // 2) Switch back to the itinerary tab
                   setSelectedOption('Itinerary');
                 }}
                 defaultRegion={defaultRegion} 
@@ -133,21 +152,25 @@ const styles = StyleSheet.create({
   keyboardAvoidingContainer: { flex: 1 },
   container: { flex: 1, backgroundColor: '#fff' },
   header: {
-    position: 'relative',
+    height: '20%',
     backgroundColor: '#f0f0f0',
-    paddingVertical: 20,
-    alignItems: 'center',
+    position: 'relative',
   },
-  backButton: {
+  homeButton: {
     position: 'absolute',
-    top: 10,
+    top: 40,
     left: 10,
     zIndex: 2,
     padding: 5,
   },
   headerText: {
+    position: 'absolute',
+    bottom: 12, 
+    left: 12,
     fontSize: 24,
     fontWeight: 'bold',
+    color: '#fff', 
+    zIndex: 2,
   },
   optionsContainer: {
     height: 50,

--- a/frontend/src/screens/itinerary-details-screen.tsx
+++ b/frontend/src/screens/itinerary-details-screen.tsx
@@ -125,7 +125,7 @@ export default function ItineraryDetailsScreen({ navigation, route }: ItineraryD
         <View style={styles.content}>
           {selectedOption === 'Itinerary' ? (
             <ScrollView style={styles.itineraryScrollView}>
-              <ItineraryLocations locations={locations} />
+              <ItineraryLocations locations={locations} itineraryId={itinerary.uuid } refreshItinerary={refreshItinerary}/>
             </ScrollView>
           ) : (
             <View style={styles.mapContent}>

--- a/frontend/src/screens/profile-screen.tsx
+++ b/frontend/src/screens/profile-screen.tsx
@@ -777,7 +777,7 @@ const styles = StyleSheet.create({
     marginLeft: 10,
   },
   clearButton: {
-    alignSelf: 'center',
+    alignSelf: 'flex-start',
     padding: 5,
     marginVertical: 10,
   },

--- a/frontend/src/screens/profile-screen.tsx
+++ b/frontend/src/screens/profile-screen.tsx
@@ -22,6 +22,7 @@ import { ProfilePosts, Post } from '../components/profile-posts';
 import useAuthStore from "../stores/auth.store";
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import apiClient from '../services/api-client';
+import { clearLocalJournals } from '../components/clear-local-journals';
 
 type RootStackParamList = {
   Home: undefined;
@@ -356,6 +357,18 @@ export default function TravelDiaryScreen({ navigation }: JournalScreenProps) {
           <Ionicons name="log-out-outline" size={24} color="white" />
           <Text style={styles.logoutText}>Logout</Text>
         </TouchableOpacity>
+
+        <TouchableOpacity 
+            style={styles.clearButton} 
+            onPress={async () => {
+              await clearLocalJournals();
+              // Optionally, also clear your local state if needed:
+              setJournals([]);
+              setJournalEntries([]);
+            }}
+          >
+            <Text style={styles.clearButtonText}>Clear Local Journals</Text>
+          </TouchableOpacity>
 
       </ScrollView>
     );
@@ -762,5 +775,15 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     marginLeft: 10,
+  },
+  clearButton: {
+    alignSelf: 'center',
+    padding: 5,
+    marginVertical: 10,
+  },
+  clearButtonText: {
+    fontSize: 12,
+    color: '#555',
+    textDecorationLine: 'underline',
   },
 });

--- a/frontend/src/services/itinerary-service.ts
+++ b/frontend/src/services/itinerary-service.ts
@@ -29,8 +29,17 @@ export async function deleteItinerary(postId: string) {
 
 export async function getItineraryById(itineraryId: string) {
   const response = await apiClient.get(`/itineraries/${itineraryId}`);
-  return response.data; 
+  const data = response.data;
+  if (data && data.locations) {
+    // Transform each location so that it has an 'id' property based on its uuid
+    data.locations = data.locations.map((loc: any) => ({
+      ...loc,
+      id: loc.uuid,
+    }));
+  }
+  return data;
 }
+
 
 interface AddLocationData {
   photoURI: string;
@@ -43,4 +52,16 @@ export async function addLocationToItinerary(itineraryId: string, locationData: 
   const response = await apiClient.post(`/itineraries/${itineraryId}/location`, locationData);
 
   return response.data;
+}
+
+export async function deleteLocationFromItinerary(itineraryId: string, locationId: string) {
+  try {
+    const response = await apiClient.delete(
+      `/itineraries/${itineraryId}/location/${locationId}`
+    );
+    return response.data;
+  } catch (error) {
+    console.error('Failed to delete location from itinerary:', error);
+    throw error;
+  }
 }

--- a/frontend/src/services/maps-service.ts
+++ b/frontend/src/services/maps-service.ts
@@ -15,7 +15,7 @@ export const getCoordinates = async (address: string) => {
         console.error("Error fetching location data:", error.response?.data?.message || error.message);
         return null;
     }
-};
+};  
 
 export const getPlaceDetails = async (placeId: string) => {
     try {
@@ -39,4 +39,23 @@ export async function getLatLngFromAddress(address: string) {
     }
 
     throw new Error('No geocode results found');
+};
+
+export async function getFirstImageForItineraryTitle(query: string) {
+    const response = await apiClient.get('/maps/search', { params: { query } });
+    const data = response.data;
+    console.log(data);
+    if (data && data.length > 0) {
+      const placeId = data[0].place_id;
+      if (!placeId) {
+        throw new Error('No place_id found in search results');
+      }
+      const details = await getPlaceDetails(placeId);
+      if (details && details.photos && details.photos.length > 0) {
+        const firstPhotoRef = details.photos[0].photo_reference;
+        return `https://maps.googleapis.com/maps/api/place/photo?maxwidth=800&photoreference=${firstPhotoRef}&key=AIzaSyBwDfYSVR0oQWqoFR7hOPgqK_JChCNlSoI`;
+      }
+      throw new Error('No photos found in place details');
+    }
+    throw new Error('No search results found');
   }


### PR DESCRIPTION
- Itinerary locations can now be properly deleted via the itinerary screen dropdown menu.
- Itineraries themselves can also be properly deleted via the home-screen dropdown menu.
- Home-screen itineraries now have proper related background images.
- User can now tap on an image on the popup after searching and view it fully before tapping off again.
- Changed itinerary creation screen and full itinerary screen UI. 
- Added small local-journal clear button below the logout button.